### PR TITLE
Improve CUDA arch detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,24 @@ set(CMAKE_CXX_FLAGS_RELEASE
 
 
 # 5) GPU architecture for LibTorch
-set(TORCH_CUDA_ARCH_LIST "8.9")
+# Try to use environment variable `TORCH_CUDA_ARCH_LIST` if provided.
+# Otherwise attempt to detect the compute capability of the first CUDA device
+# via a short Python snippet. When detection fails, leave the variable unset
+# so LibTorch can decide a suitable default.
+if(DEFINED ENV{TORCH_CUDA_ARCH_LIST})
+  set(TORCH_CUDA_ARCH_LIST "$ENV{TORCH_CUDA_ARCH_LIST}")
+else()
+  execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import torch,sys; cc=torch.cuda.get_device_capability(0); print(f'{cc[0]}.{cc[1]}')"
+    RESULT_VARIABLE TORCH_CC_RES
+    OUTPUT_VARIABLE TORCH_CC_OUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(TORCH_CC_RES EQUAL 0)
+    set(TORCH_CUDA_ARCH_LIST "${TORCH_CC_OUT}")
+  endif()
+endif()
 
 # Pull in Python & PyBind11 & Torch
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)


### PR DESCRIPTION
## Summary
- determine Torch CUDA arch at configure time instead of hardcoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840285397d48321aceca110b0233d68