### PR TITLE
Add setup script for building chess_engine

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure a CUDA-capable GPU is available
+python3 - <<'PY'
+import torch
+if not torch.cuda.is_available():
+    raise SystemExit(1)
+PY
+
+mkdir -p build
+cd build
+cmake -DCMAKE_PREFIX_PATH="$(python3 -c 'import torch;print(torch.utils.cmake_prefix_path)')" ..
+make -j"$(nproc)"
+
+# Move the generated extension into the Python package directory
+mv chess_engine*.so ../src/python/


### PR DESCRIPTION
## Summary
- add scripts/setup.sh for GPU check and building the C++ extension
- fix quoting and make -j usage

## Testing
- `./scripts/setup.sh` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6840284ac86483218630c0d8fdc77b19