### PR TITLE
Update include path for chess-library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(Torch REQUIRED)
 # Includes
 include_directories(
   ${CMAKE_SOURCE_DIR}/src/cpp/include
-  ${CMAKE_SOURCE_DIR}/lib/chess-library
+  ${CMAKE_SOURCE_DIR}/lib/chess-library/include
   ${TORCH_INCLUDE_DIRS}
   ${Python3_INCLUDE_DIRS}
 )


### PR DESCRIPTION
## Summary
- update chess-library include path in `CMakeLists.txt`

## Testing
- `pip install -r requirements.txt` *(fails: building torch)*
- `cmake -B build -S .` *(fails: Could not find pybind11)*

------
https://chatgpt.com/codex/tasks/task_e_6840429c8810832190899e073d7892df