### PR TITLE
Fix eval to use updated TorchScript

### DIFF
--- a/src/python/train_cpp.py
+++ b/src/python/train_cpp.py
@@ -300,7 +300,7 @@ def main():
         if iteration % args.evaluate_each == 0:
             new_ts = f"model_ts_{iteration}_eval.pt"
             subprocess.run(["python3", "export_torchscript.py", args.model_path, new_ts], check=True)
-            spawn_async_evaluation(iteration, ts_path, args, writer)
+            spawn_async_evaluation(iteration, new_ts, args, writer)
             torch.cuda.empty_cache()
 
         # periodic checkpoint


### PR DESCRIPTION
## Summary
- update evaluation to send the newly exported TorchScript file

## Testing
- `python3 -m py_compile src/python/train_cpp.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840506bb4f483219239f2e9fae42e22